### PR TITLE
Fix application of addMobileStyle in beforeShow() 

### DIFF
--- a/jquery.mobile.datepicker.js
+++ b/jquery.mobile.datepicker.js
@@ -57,7 +57,7 @@
           var self = this;
             setTimeout( function(){
                 $(element)
-                  .data("mobileDate").addMobileStyle();
+                  .date( "addMobileStyle" );
             },0);
         },// Define a callback function when the month or year is changed
 		numberOfMonths: 1, // Number of months to show at a time


### PR DESCRIPTION
I believe this was a typo in the last commit that was fixing the application of styles. Without this change, the browser chokes on the modified line because ".data("mobileDate") is null.
