### PR TITLE
Fixed the creation of an inline datepicker

### DIFF
--- a/jquery.mobile.datepicker.js
+++ b/jquery.mobile.datepicker.js
@@ -92,7 +92,7 @@ $.widget("mobile.date",{
 			calendar = this.element.datepicker( "widget" );
 		}
 
-		this.baseWidget = ( !this.options.inline )? this.element: this.calendar;
+		this.baseWidget = ( !this.options.inline )? this.element: calendar;
 
 		if ( this.options.inline ) {
 			this._on({


### PR DESCRIPTION
In the _create method a this.calendar reference was used but this is always undefined because the calendar local variable is used. Just replaced it with the variable.
