### PR TITLE
Leading underscore required to override _setOption

### DIFF
--- a/jquery.mobile.datepicker.js
+++ b/jquery.mobile.datepicker.js
@@ -102,7 +102,7 @@ $.widget("mobile.date",{
 			});
 		}
 	},
-	setOption:function( key, value ){
+	_setOption:function( key, value ){
 		this.baseWidget.datepicker( "option", key, value );
 	},
 	getDate: function(){


### PR DESCRIPTION
http://api.jqueryui.com/jQuery.widget/#method-_setOption

I believe this is broken without this fix
